### PR TITLE
Implement puzzle auth scripts

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -16,4 +16,5 @@ Usage:
 ```bash
 ./lispenv.sh            # once, to install SBCL/Quicklisp
 source ./setup-auth.sh  # generate keys and export variables
+source ./puzzle.sh      # requires DO_API_TOKEN and CODEX_PUB_KEY
 ```

--- a/auth/puzzle.lisp
+++ b/auth/puzzle.lisp
@@ -1,0 +1,27 @@
+(load (merge-pathnames "cryptodex-init.lisp" (or *load-pathname* (user-homedir-pathname))))
+(ql:quickload '(:ironclad :babel :uiop))
+
+(in-package #:cl-user)
+
+(defun sha256-hex (str)
+  (ironclad:byte-array-to-hex-string
+    (ironclad:digest-sequence :sha256 (babel:string-to-octets str :encoding :utf-8))))
+
+(defun compute-password (token pubkey)
+  (sha256-hex (concatenate 'string token pubkey)))
+
+(defun compute-username (timestamp password)
+  (sha256-hex (concatenate 'string timestamp password)))
+
+(defun main ()
+  (let* ((token (uiop:getenv "DO_API_TOKEN"))
+         (pub (uiop:getenv "CODEX_PUB_KEY"))
+         (timestamp (or (uiop:getenv "CODEX_TIMESTAMP")
+                        (write-to-string (get-universal-time))))
+         (password (compute-password token pub))
+         (username (compute-username timestamp password)))
+    (format t "export CODEX_USERNAME='~A'~%" username)
+    (format t "export CODEX_PASSWORD='~A'~%" password)
+    (format t "export CODEX_TIMESTAMP='~A'~%" timestamp)))
+
+(main)

--- a/auth/puzzle.sh
+++ b/auth/puzzle.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Run puzzle algorithm and export CODEX_USERNAME, CODEX_PASSWORD and CODEX_TIMESTAMP
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Evaluate the Lisp script which prints export commands
+eval "$(sbcl --script "$SCRIPT_DIR/puzzle.lisp")"

--- a/auth/server/poll_puzzle.sh
+++ b/auth/server/poll_puzzle.sh
@@ -8,9 +8,14 @@ API_URL="https://api.digitalocean.com/v2/droplets/$DROPLET_ID"
 
 while true; do
   name=$(curl -sSL -H "Authorization: Bearer $DO_API_TOKEN" "$API_URL" | jq -r '.droplet.name')
-  if [[ "$name" != "null" && "$name" != "" ]]; then
-    echo "Puzzle detected: $name"
-    # TODO: solve puzzle here and derive password
+  if [[ "$name" == puzzle-* ]]; then
+    timestamp="${name#puzzle-}"
+    echo "Puzzle timestamp: $timestamp"
+    CODEX_TIMESTAMP="$timestamp" DO_API_TOKEN="$DO_API_TOKEN" \
+      CODEX_PUB_KEY="${CODEX_PUB_KEY:-}" \
+      source "$(dirname "$0")/../puzzle.sh"
+    echo "Username: $CODEX_USERNAME"
+    echo "Password: $CODEX_PASSWORD"
     break
   fi
   sleep 5


### PR DESCRIPTION
## Summary
- add `puzzle.lisp` implementing puzzle algorithm
- add helper `puzzle.sh`
- integrate puzzle generation in `poll_puzzle.sh`
- document puzzle usage in README

## Testing
- `shellcheck auth/puzzle.sh auth/server/poll_puzzle.sh -e SC1091`
- `sbcl --version`
- `DO_API_TOKEN="dummy" CODEX_PUB_KEY="pubkey" CODEX_TIMESTAMP="123" sbcl --script auth/puzzle.lisp` *(fails: Couldn't load Quicklisp)*

------
https://chatgpt.com/codex/tasks/task_e_6881d00e4bf8832997a33be195a30dcb